### PR TITLE
A11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ There are sometimes multiple words for the same thing, again - just to be confus
                                                                              📖
 
 
+**A11y**  A numeronym for accessibility, where the number 11 refers to the number of letters omitted. A11y refers to the accessibility of a computer system to all people, regardless of disability type or severity of impairment.
+
 **API** - Stands for Application Programming Interface, which provides a comprehensive layer of communication and callbacks to the original software layer, so that it becomes easier to integrate. Example- The google maps API allows you to integrate their maps to your apps through their API.
                                                            
 **Boilerplate** (code) - The standard code you need to put into your code in order for it to run. An example is frameworks. Let’s take Bootstrap as an example. To use it, you need to copy and paste in a bunch of code that you get from the official website in order for you to be able to use it. Like a template.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are sometimes multiple words for the same thing, again - just to be confus
                                                                              📖
 
 
-**A11y**  A numeronym for accessibility, where the number 11 refers to the number of letters omitted. A11y refers to the accessibility of a computer system to all people, regardless of disability type or severity of impairment.
+**A11y** - A numeronym for accessibility, where the number 11 refers to the number of letters omitted. A11y refers to the accessibility of a computer system to all people, regardless of disability type or severity of impairment.
 
 **API** - Stands for Application Programming Interface, which provides a comprehensive layer of communication and callbacks to the original software layer, so that it becomes easier to integrate. Example- The google maps API allows you to integrate their maps to your apps through their API.
                                                            


### PR DESCRIPTION
Adding A11y.

Feel free to change the text, since my english isn't perfect!

A11y - A numeronym for accessibility, where the number 11 refers to the number of letters omitted. A11y refers to the accessibility of a computer system to all people, regardless of disability type or severity of impairment.